### PR TITLE
Wait for the existing chat room messages to load then scroll bottom

### DIFF
--- a/js/chatroom_app.js
+++ b/js/chatroom_app.js
@@ -12,7 +12,9 @@ chat_app.controller('chat_controller', [ '$rootScope', '$scope', '$http', '$fire
 			var fire_chatroom = $firebase( new Firebase( fireData.fire_url ).child( $scope.chatroom.ID )).$asObject();
 			fire_chatroom.$bindTo( $scope, 'fireChat' ).then(function(){
 				console.log('chat messages init..');
-				$scope.scrollChat();
+				setTimeout(function() {
+					$scope.scrollChat();
+				}, 100);
 			});
 		});
 	}


### PR DESCRIPTION
Wrapping `$scope.scrollChat();` execution inside a `setTimeout()` with a tiny small amount of milliseconds works to give a break and let the existing chat messages to be loaded before, then scroll to bottom is successful when chat room page loads first time. Not sure if this would be the best accurate but does the trick. I was researching for some callback function to use in `$bindTo()` which could do a better job than `.then()`, something like `.success()`, `.loaded()`, `.ready()`, something that actually detects and executes when the existing chat messages are already loaded, but could't find any.

Merge this approach if you like it in the meantime, but I agree there's is a better method to do this.
